### PR TITLE
Apply conversion of basic HTML tags to markdown

### DIFF
--- a/src/generator.lua
+++ b/src/generator.lua
@@ -16,11 +16,38 @@ local generator = {}
 --
 -- Local
 
----Decode text to get rid of html tags and entities
+-- Apply a list of inline tag rules, replacing html tags with their corresponding markdown syntax
+---@param s string
+---@param rules table
+---@return string
+local function apply_inline_rules(s, rules)
+  for _, rule in ipairs(rules) do
+    for _, tag in ipairs(rule.tags) do
+      s = s:gsub('<' .. tag .. '>(.-)</' .. tag .. '>', function(inner)
+        return rule.wrap .. inner .. rule.wrap
+      end)
+    end
+  end
+  return s
+end
+
+---Decode text to get rid of unnecessary html tags and entities
 ---@param text string
 ---@return string
 local function decode_text(text)
-  local result = text:gsub('%b<>', '')
+  local result = text or ''
+
+  local formatRules = {
+    { tags = { 'code' },        wrap = '`' },
+    { tags = { 'strong', 'b' }, wrap = '**' },
+    { tags = { 'em', 'i' },     wrap = '*' },
+  }
+
+  result = apply_inline_rules(result, formatRules)
+
+  -- Strip any remaining html tags
+  result = result:gsub('%b<>', '')
+
   local decoded_result = html_entities.decode(result)
 
   if type(decoded_result) == 'string' then


### PR DESCRIPTION
I find it particularly helpful to have formatting applied in code docs as it makes things easier to read:

Before
<img width="1022" height="294" alt="image" src="https://github.com/user-attachments/assets/02e83cfc-5104-465b-896f-372755b9638c" />

After
<img width="1047" height="285" alt="image" src="https://github.com/user-attachments/assets/59436293-b828-4b6e-ac6b-9d94b5c10505" />
